### PR TITLE
Fix test failure on Python 3.6

### DIFF
--- a/tests/test_trashcan.py
+++ b/tests/test_trashcan.py
@@ -92,32 +92,37 @@ class TestSimple(Checks):
 
     @pytest.fixture
     def trashcan(self):
-        return Trashcan()
+        with Trashcan() as trashcan:
+            yield trashcan
 
 
 class TestThreads(Checks):
 
     @pytest.fixture
     def trashcan(self):
-        return Trashcan(threads=1)
+        with Trashcan(threads=1) as trashcan:
+            yield trashcan
 
 
 class TestProcesses(Checks):
 
     @pytest.fixture
     def trashcan(self):
-        return Trashcan(processes=1)
+        with Trashcan(processes=1) as trashcan:
+            yield trashcan
 
 
 class TestProcessesAndThreads(Checks):
 
     @pytest.fixture
     def trashcan(self):
-        return Trashcan(processes=1, threads=1)
+        with Trashcan(processes=1, threads=1) as trashcan:
+            yield trashcan
 
 
 class TestMany(Checks):
 
     @pytest.fixture
     def trashcan(self):
-        return Trashcan(processes=4, threads=16)
+        with Trashcan(processes=4, threads=16) as trashcan:
+            yield trashcan

--- a/trashcan/__init__.py
+++ b/trashcan/__init__.py
@@ -56,6 +56,12 @@ class Trashcan:
         else:
             self.submit = _run
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.shutdown()
+
     def shutdown(self):
         if self.executor is not None:
             self.executor.shutdown()


### PR DESCRIPTION
Still not sure why this was only affecting 3.6 though